### PR TITLE
Add TypeScript declarations

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,21 @@
+declare module 'unvault' {
+  /**
+   * Selects a tracker in the vault.
+   */
+  function find(key: string): any;
+
+  /**
+   * Inserts a tracker into the vault.
+   */
+  function insert(key: string, interval: number, update: Function, value?: any): void;
+
+  /**
+   * Removes a tracker from the vault.
+   */
+  function remove(key: string): boolean;
+
+  /**
+   * Trigger a tracker to update its value.
+   */
+  function trigger(key: string, automated?: boolean): Promise<any>;
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A minimal layer for node that allows results of time-consuming tasks to be stored.",
   "repository": "vaneenige/unvault",
   "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
   "license": "MIT",
   "files": [
     "lib"
@@ -19,10 +20,8 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "mocha": "^5.0.0",
-    "sinon": "^4.2.1"
-  },
-  "dependencies": {
     "mongodb": "^2.2.33",
-    "polka": "^0.2.3"
+    "polka": "^0.2.3",
+    "sinon": "^4.2.1"
   }
 }


### PR DESCRIPTION
Heyo 👋

I've added some TypeScript type definitions, along with moving `mongodb` and `polka` to `devDependencies` instead of `dependencies`, since they are only used in the benchmark and don't need to be installed when running `npm install unvault`.